### PR TITLE
 fix: make sure camera sticks to player object, offload camera offset…

### DIFF
--- a/js/FPSControls.js
+++ b/js/FPSControls.js
@@ -14,6 +14,11 @@ THREE.PointerLockControls = function ( camera, mass, playerHeight, doubleJump, w
 	pitchObject.add( camera );
 
 	var yawObject = new THREE.Object3D();
+
+	// move camera's position/offset to yawObject
+	yawObject.position.copy(camera.position);
+	camera.position.set(0, 0, 0);
+
 	yawObject.position.y = playerHeight;
 	yawObject.add( pitchObject );
 


### PR DESCRIPTION
hi, I found when the camera isn't at  (0, 0, 0),  after setup controls,  camera is not attached to player object,  give the strange FPS experience.   which doesn't look around, but rotate viewport at point in front of player. 

so i move position offset of camera to player object to fix.

it is  not issue in  game/index.html but a logic flaw when i playaround with the code.

-Frank
